### PR TITLE
Fix issue with iPhoneX

### DIFF
--- a/lib/flick/video.rb
+++ b/lib/flick/video.rb
@@ -144,7 +144,7 @@ class Video
 
   def convert_images_to_mp4
     remove_zero_byte_images
-    %x(ffmpeg -loglevel quiet -framerate #{rate} -pattern_type glob -i '#{driver.flick_dir}/screenshot-#{udid}*.png' -c:v libx264 -pix_fmt yuv420p #{driver.flick_dir}/#{driver.name}.mp4)
+    %x(ffmpeg -loglevel quiet -framerate #{rate} -pattern_type glob -i '#{driver.flick_dir}/screenshot-#{udid}*.png' -c:v libx264 -pix_fmt yuv420p -vf "scale=trunc(iw/2)*2:trunc(ih/2)*2" #{driver.flick_dir}/#{driver.name}.mp4)
   end
 
   def remove_zero_byte_images


### PR DESCRIPTION
**The problem**
Even though flick was generating the screenshots for iPhoneX the video produced was 0 bytes.

I saw that the images were passed to ffmpeg so I figured that the issue was there. Apparently, ffmpeg does not like the size of the screenshots and produced the following error:
`width not divisible by 2 (1125x2436)`

**The solution**
As you can see this is a one line fix, simply passing scale arguments to ffmpeg is enough.
I think this does not break the vid creation for other devices.

Tested on:
**iOS**
- iPhone SE
- iPhone 8
- iPhone X

**Android**
- Google Pixel
- Google Pixel 2
- Nexus 5X