### PR TITLE
Fix video issue in Android

### DIFF
--- a/lib/flick/android.rb
+++ b/lib/flick/android.rb
@@ -174,7 +174,7 @@ module Flick
         command = "md5sum"
       end
       files = %x(adb -s #{udid} shell "#{command} #{dir_name}/#{type}*")
-      hash = files.split("\r\n").map { |file| { md5: file.match(/(.*) /)[1].strip, file: file.match(/ (.*)/)[1].strip } }
+      hash = files.split(/[\r\n]+/).map { |file| { md5: file.match(/(.*) /)[1].strip, file: file.match(/ (.*)/)[1].strip } }
       hash.uniq! { |e| e[:md5] }
       hash.map { |file| file[:file] }
     end

--- a/lib/flick/video.rb
+++ b/lib/flick/video.rb
@@ -94,7 +94,7 @@ class Video
     Flick::System.kill_process "video", udid
     sleep 5 #wait for video process to finish
     driver.pull_files "video"
-    files = Dir.glob("#{driver.flick_dir}/video-#{udid}*.mp4")
+	files = Dir.glob("#{driver.flick_dir}/video-#{udid}*.mp4").sort
     return if files.empty?
     files.each { |file| system("mp4box -cat #{file} #{driver.flick_dir}/#{driver.name}.mp4") }
     puts "Saving to #{driver.outdir}/#{driver.name}.#{format}"


### PR DESCRIPTION
Hello @isonic1 ,

This is another PR from me :)

This fixes https://github.com/isonic1/flick/issues/39 and https://github.com/isonic1/flick/issues/40 

### The problem

Video for Android seems to not work for videos larger than 3 mins

### The cause

Results from md5sum on the video directory were not parsed correctly.
In detail, while the videos were saved correctly in sdcard/flick , the output was not split correctly causing only the first video to be output.

### The solution

The solution is to use a regexp to parse the files correctly and add them into the hash for later processing. I also had to sort the results from Dir.glob because in my mac the results were not sorted causing wrong sequences in the final video.

